### PR TITLE
feat: improve SEO metadata

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,3 +4,5 @@ source "https://rubygems.org"
 
 gemspec
 
+gem "jekyll-seo-tag"
+

--- a/_config.yml
+++ b/_config.yml
@@ -256,6 +256,7 @@ exclude:
 plugins:
   - jekyll-paginate
   - jekyll-sitemap
+  - jekyll-seo-tag
 
 #remote_theme: daattali/beautiful-jekyll@5.0.0
 

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -157,4 +157,5 @@
     {% endfor %}
   {% endif %}
 
+  {% seo %}
 </head>


### PR DESCRIPTION
## Summary
- add jekyll-seo-tag plugin
- enable `{% seo %}` tag in head for richer metadata

## Testing
- `bundle install` *(fails: Net::HTTPClientException 403 "Forbidden")*
- `bundle exec jekyll build` *(fails: bundler: command not found: jekyll)*

------
https://chatgpt.com/codex/tasks/task_e_688ec4bca73883218116d60161bb90ce